### PR TITLE
DryAutoInject and TokenDecoder/LocalUserMapper extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ The user repository will be used to look for an entity to mark as authenticated,
 - `find_by_cognito_username` that should return the user identified by the given username or nil
 - `find_by_cognito_attribute` that should return the user identified by the given Cognito User attribute (`config.identifying_attribute`) or nil
 
+### User Model
+
+The user model must expose a message `cognito_id` that returns the `identifying_attribute` for the given user.
+
 ### `after_local_user_not_found` Callback
 
 A callback triggered whenever the user correctly authenticated on Cognito but no local user exists (receives the full [cognito user](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/CognitoIdentityProvider/Types/GetUserResponse.html))

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 
 ## Usage
 
-Add to  your initializers the following:
+Configure how the gem maps Cognito users to local ones adding to your initializers the following:
 ```ruby
  Warden::Cognito.configure do |config|
     config.user_repository = User
@@ -38,6 +38,35 @@ This gem will look for the following the env variables:
 - **AWS_REGION**
 - **AWS_COGNITO_USER_POOL_ID**
 - **AWS_COGNITO_CLIENT_ID**
+
+### With Devise
+
+You can know protects endpoints by settings the available strategies in the Warden section of your Device's configuration:
+```ruby
+  # config/initializers/devise.rb
+  # 
+  # /***/
+  config.warden do |manager|
+    manager.default_strategies(scope: :user).unshift :cognito_auth
+    manager.default_strategies(scope: :user).unshift :cognito_jwt
+    # /***/
+  end
+```
+
+### API
+
+This gem also exposes classes that you can use to validate tokens and/or fetch a user from a given token:
+
+```ruby
+token = 'The token a user passed along in a request'
+token_decoder = TokenDecoder.new(token)
+
+# Is the token valid ?
+token_decoder.validate!
+
+# Who is the local user associated with this token
+user = LocalUserMapper.new.call(token_decoder)
+```
 
 ### User Repository
 

--- a/lib/warden/cognito.rb
+++ b/lib/warden/cognito.rb
@@ -11,7 +11,7 @@ module Warden
     extend Dry::Configurable
 
     setting :user_repository
-    setting :identifying_attribute, 'sub'
+    setting(:identifying_attribute, 'sub', &:to_s)
     setting :after_local_user_not_found
     setting :cache, ActiveSupport::Cache::NullStore.new
 
@@ -19,8 +19,12 @@ module Warden
   end
 end
 
+require 'warden/cognito/jwk_loader'
 require 'warden/cognito/version'
+require 'warden/cognito/user_not_found_callback'
+require 'warden/cognito/local_user_mapper'
 require 'warden/cognito/authenticatable_strategy'
 require 'warden/cognito/token_authenticatable_strategy'
+require 'warden/cognito/token_decoder'
 require 'warden/cognito/user_helper'
 require 'warden/cognito/cognito_client'

--- a/lib/warden/cognito.rb
+++ b/lib/warden/cognito.rb
@@ -10,10 +10,22 @@ module Warden
   module Cognito
     extend Dry::Configurable
 
+    def jwk_config_keys
+      %i[key issuer]
+    end
+
+    # rubocop:disable Style/AccessModifierDeclarations
+    module_function :jwk_config_keys
+    # rubocop:enable Style/AccessModifierDeclarations
+
     setting :user_repository
     setting(:identifying_attribute, 'sub', &:to_s)
     setting :after_local_user_not_found
     setting :cache, ActiveSupport::Cache::NullStore.new
+
+    setting(:jwk, nil) do |value|
+      Struct.new(*jwk_config_keys, keyword_init: true).new(**(value&.symbolize_keys&.slice(*jwk_config_keys) || {}))
+    end
 
     Import = Dry::AutoInject(config)
   end
@@ -28,3 +40,4 @@ require 'warden/cognito/token_authenticatable_strategy'
 require 'warden/cognito/token_decoder'
 require 'warden/cognito/user_helper'
 require 'warden/cognito/cognito_client'
+require 'warden/cognito/test_helpers'

--- a/lib/warden/cognito.rb
+++ b/lib/warden/cognito.rb
@@ -14,18 +14,19 @@ module Warden
       %i[key issuer]
     end
 
-    # rubocop:disable Style/AccessModifierDeclarations
-    module_function :jwk_config_keys
-    # rubocop:enable Style/AccessModifierDeclarations
+    def jwk_instance(value)
+      attributes = value&.symbolize_keys&.slice(*jwk_config_keys) || {}
+      Struct.new(*jwk_config_keys, keyword_init: true).new(attributes)
+    end
+
+    module_function :jwk_config_keys, :jwk_instance
 
     setting :user_repository
     setting(:identifying_attribute, 'sub', &:to_s)
     setting :after_local_user_not_found
     setting :cache, ActiveSupport::Cache::NullStore.new
 
-    setting(:jwk, nil) do |value|
-      Struct.new(*jwk_config_keys, keyword_init: true).new(**(value&.symbolize_keys&.slice(*jwk_config_keys) || {}))
-    end
+    setting(:jwk, nil) { |value| jwk_instance(value) }
 
     Import = Dry::AutoInject(config)
   end

--- a/lib/warden/cognito/jwk_loader.rb
+++ b/lib/warden/cognito/jwk_loader.rb
@@ -2,12 +2,15 @@ module Warden
   module Cognito
     class JwkLoader
       include Cognito::Import['cache']
+      include Cognito::Import['jwk']
 
       def jwt_issuer
-        "https://cognito-idp.#{ENV['AWS_REGION']}.amazonaws.com/#{ENV['AWS_COGNITO_USER_POOL_ID']}"
+        jwk.issuer || "https://cognito-idp.#{ENV['AWS_REGION']}.amazonaws.com/#{ENV['AWS_COGNITO_USER_POOL_ID']}"
       end
 
       def call(options)
+        return { keys: [jwk.key.export] } if jwk.key.present?
+
         cache.clear(jwk_url) if options[:invalidate]
 
         cache.fetch(jwk_url, expires_in: 1.hour) do

--- a/lib/warden/cognito/jwk_loader.rb
+++ b/lib/warden/cognito/jwk_loader.rb
@@ -11,7 +11,7 @@ module Warden
       def call(options)
         return { keys: [jwk.key.export] } if jwk.key.present?
 
-        cache.clear(jwk_url) if options[:invalidate]
+        cache.delete(jwk_url) if options[:invalidate]
 
         cache.fetch(jwk_url, expires_in: 1.hour) do
           JSON.parse(HTTP.get(jwk_url).body.to_s).deep_symbolize_keys

--- a/lib/warden/cognito/jwk_loader.rb
+++ b/lib/warden/cognito/jwk_loader.rb
@@ -1,0 +1,25 @@
+module Warden
+  module Cognito
+    class JwkLoader
+      include Cognito::Import['cache']
+
+      def jwt_issuer
+        "https://cognito-idp.#{ENV['AWS_REGION']}.amazonaws.com/#{ENV['AWS_COGNITO_USER_POOL_ID']}"
+      end
+
+      def call(options)
+        cache.clear(jwk_url) if options[:invalidate]
+
+        cache.fetch(jwk_url, expires_in: 1.hour) do
+          JSON.parse(HTTP.get(jwk_url).body.to_s).deep_symbolize_keys
+        end
+      end
+
+      private
+
+      def jwk_url
+        "#{jwt_issuer}/.well-known/jwks.json"
+      end
+    end
+  end
+end

--- a/lib/warden/cognito/local_user_mapper.rb
+++ b/lib/warden/cognito/local_user_mapper.rb
@@ -3,6 +3,16 @@ module Warden
     class LocalUserMapper
       include Cognito::Import['cache', 'identifying_attribute']
 
+      class << self
+        def find(token_decoder)
+          new.call(token_decoder)
+        end
+
+        def find_by_token(token)
+          find(TokenDecoder.new(token))
+        end
+      end
+
       def call(token_decoder)
         helper.find_by_cognito_attribute local_identifier(token_decoder)
       end

--- a/lib/warden/cognito/local_user_mapper.rb
+++ b/lib/warden/cognito/local_user_mapper.rb
@@ -1,0 +1,24 @@
+module Warden
+  module Cognito
+    class LocalUserMapper
+      include Cognito::Import['cache', 'identifying_attribute']
+
+      def call(token_decoder)
+        helper.find_by_cognito_attribute local_identifier(token_decoder)
+      end
+
+      private
+
+      def local_identifier(token_decoder)
+        cache_key = "COGNITO_LOCAL_IDENTIFIER_#{token_decoder.sub}"
+        cache.fetch(cache_key, skip_nil: true) do
+          token_decoder.user_attribute(identifying_attribute)
+        end
+      end
+
+      def helper
+        UserHelper.new
+      end
+    end
+  end
+end

--- a/lib/warden/cognito/test_helpers.rb
+++ b/lib/warden/cognito/test_helpers.rb
@@ -1,0 +1,37 @@
+module Warden
+  module Cognito
+    class TestHelpers
+      @jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
+
+      class << self
+        attr_reader :jwk
+
+        def auth_headers(headers, user)
+          headers.merge(Authorization: "Bearer #{generate_token(user)}")
+        end
+
+        def setup
+          Warden::Cognito.config.jwk = { key: jwk, issuer: local_issuer }
+        end
+
+        def local_issuer
+          'local_issuer'
+        end
+
+        private
+
+        def generate_token(user)
+          payload = { sub: user.object_id,
+                      "#{identifying_attribute}": user.cognito_id,
+                      iss: local_issuer }
+          headers = { kid: jwk.kid }
+          JWT.encode(payload, jwk.keypair, 'RS256', headers)
+        end
+
+        def identifying_attribute
+          Warden::Cognito.config.identifying_attribute
+        end
+      end
+    end
+  end
+end

--- a/lib/warden/cognito/test_helpers.rb
+++ b/lib/warden/cognito/test_helpers.rb
@@ -1,17 +1,21 @@
+require 'rspec'
+
 module Warden
   module Cognito
     class TestHelpers
+      class EnvironmentError < StandardError; end
+
       @jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
 
       class << self
         attr_reader :jwk
 
-        def auth_headers(headers, user)
-          headers.merge(Authorization: "Bearer #{generate_token(user)}")
-        end
-
         def setup
           Warden::Cognito.config.jwk = { key: jwk, issuer: local_issuer }
+        end
+
+        def auth_headers(headers, user)
+          headers.merge(Authorization: "Bearer #{generate_token(user)}")
         end
 
         def local_issuer

--- a/lib/warden/cognito/token_authenticatable_strategy.rb
+++ b/lib/warden/cognito/token_authenticatable_strategy.rb
@@ -22,7 +22,7 @@ module Warden
       end
 
       def authenticate!
-        user = local_user || UserNotFoundCallback.new.call(cognito_user)
+        user = local_user || UserNotFoundCallback.call(cognito_user)
 
         fail!(:unknown_user) unless user.present?
         success!(user)
@@ -39,7 +39,7 @@ module Warden
       end
 
       def local_user
-        LocalUserMapper.new.call token_decoder
+        LocalUserMapper.find token_decoder
       end
 
       def token_decoder

--- a/lib/warden/cognito/token_authenticatable_strategy.rb
+++ b/lib/warden/cognito/token_authenticatable_strategy.rb
@@ -6,22 +6,15 @@ module Warden
     class TokenAuthenticatableStrategy < Warden::Strategies::Base
       METHOD = 'Bearer'.freeze
 
-      attr_reader :helper, :config
+      attr_reader :helper
 
       def initialize(env, scope = nil)
         super
-        @config = Cognito.config
-        @helper = UserHelper
-      end
-
-      def jwks
-        config.cache.fetch(jwk_url, expires_in: 1.hour) do
-          JSON.parse(HTTP.get(jwk_url).body.to_s).deep_symbolize_keys
-        end
+        @helper = UserHelper.new
       end
 
       def valid?
-        decoded_token.present?
+        token_decoder.validate!
       rescue ::JWT::ExpiredSignature
         true
       rescue StandardError
@@ -29,7 +22,8 @@ module Warden
       end
 
       def authenticate!
-        user = local_user || config.after_local_user_not_found&.call(cognito_user)
+        user = local_user || UserNotFoundCallback.new.call(cognito_user)
+
         fail!(:unknown_user) unless user.present?
         success!(user)
       rescue ::JWT::ExpiredSignature
@@ -40,49 +34,16 @@ module Warden
 
       private
 
-      def jwt_issuer
-        "https://cognito-idp.#{ENV['AWS_REGION']}.amazonaws.com/#{ENV['AWS_COGNITO_USER_POOL_ID']}"
-      end
-
-      def jwk_url
-        "#{jwt_issuer}/.well-known/jwks.json"
+      def cognito_user
+        token_decoder.cognito_user
       end
 
       def local_user
-        helper.find_by_cognito_attribute(local_identifier)
+        LocalUserMapper.new.call token_decoder
       end
 
-      def cognito_user_cache_key
-        "COGNITO_LOCAL_IDENTIFIER_#{cognito_user_identifier}"
-      end
-
-      def cognito_user_identifier
-        decoded_token.first['sub']
-      end
-
-      def local_identifier
-        config.cache.fetch(cognito_user_cache_key, skip_nil: true) do
-          user_attribute identifying_attribute
-        end
-      end
-
-      def cognito_user
-        @cognito_user ||= CognitoClient.fetch(token)
-      end
-
-      def user_attribute(attribute_name)
-        cognito_user.user_attributes.detect do |attribute|
-          attribute.name == attribute_name
-        end&.value
-      end
-
-      def identifying_attribute
-        config.identifying_attribute.to_s
-      end
-
-      def decoded_token
-        @decoded_token ||= ::JWT.decode(token, nil, true, iss: jwt_issuer, verify_iss: true,
-                                                          algorithms: ['RS256'], jwks: jwks)
+      def token_decoder
+        @token_decoder ||= TokenDecoder.new(token)
       end
 
       def token

--- a/lib/warden/cognito/token_decoder.rb
+++ b/lib/warden/cognito/token_decoder.rb
@@ -1,0 +1,35 @@
+module Warden
+  module Cognito
+    class TokenDecoder
+      attr_reader :jwk_loader, :token
+
+      def initialize(token)
+        @token = token
+        @jwk_loader = JwkLoader.new
+      end
+
+      def validate!
+        decoded_token.present?
+      end
+
+      def sub
+        decoded_token.first['sub']
+      end
+
+      def decoded_token
+        @decoded_token ||= ::JWT.decode(token, nil, true, iss: jwk_loader.jwt_issuer, verify_iss: true,
+                                                          algorithms: ['RS256'], jwks: jwk_loader)
+      end
+
+      def cognito_user
+        @cognito_user ||= CognitoClient.fetch(token)
+      end
+
+      def user_attribute(attribute_name)
+        cognito_user.user_attributes.detect do |attribute|
+          attribute.name == attribute_name
+        end&.value
+      end
+    end
+  end
+end

--- a/lib/warden/cognito/token_decoder.rb
+++ b/lib/warden/cognito/token_decoder.rb
@@ -26,6 +26,16 @@ module Warden
       end
 
       def user_attribute(attribute_name)
+        token_attribute(attribute_name).presence || cognito_user_attribute(attribute_name)
+      end
+
+      private
+
+      def token_attribute(attribute_name)
+        decoded_token.first[attribute_name] if decoded_token.first.key? attribute_name
+      end
+
+      def cognito_user_attribute(attribute_name)
         cognito_user.user_attributes.detect do |attribute|
           attribute.name == attribute_name
         end&.value

--- a/lib/warden/cognito/user_helper.rb
+++ b/lib/warden/cognito/user_helper.rb
@@ -1,20 +1,14 @@
 module Warden
   module Cognito
-    module UserHelper
-      class << self
-        def find_by_cognito_username(username)
-          user_repository.find_by_cognito_username(username)
-        end
+    class UserHelper
+      include Cognito::Import['user_repository']
 
-        def find_by_cognito_attribute(arg)
-          user_repository.find_by_cognito_attribute(arg)
-        end
+      def find_by_cognito_username(username)
+        user_repository.find_by_cognito_username(username)
+      end
 
-        private
-
-        def user_repository
-          Cognito.config.user_repository
-        end
+      def find_by_cognito_attribute(arg)
+        user_repository.find_by_cognito_attribute(arg)
       end
     end
   end

--- a/lib/warden/cognito/user_not_found_callback.rb
+++ b/lib/warden/cognito/user_not_found_callback.rb
@@ -3,6 +3,12 @@ module Warden
     class UserNotFoundCallback
       include Cognito::Import['after_local_user_not_found']
 
+      class << self
+        def call(cognito_user)
+          new.call(cognito_user)
+        end
+      end
+
       def call(cognito_user)
         after_local_user_not_found&.call(cognito_user)
       end

--- a/lib/warden/cognito/user_not_found_callback.rb
+++ b/lib/warden/cognito/user_not_found_callback.rb
@@ -1,0 +1,11 @@
+module Warden
+  module Cognito
+    class UserNotFoundCallback
+      include Cognito::Import['after_local_user_not_found']
+
+      def call(cognito_user)
+        after_local_user_not_found&.call(cognito_user)
+      end
+    end
+  end
+end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -6,6 +6,10 @@ module Fixtures
   # An user record
   class User
     include Singleton
+
+    def cognito_id
+      object_id
+    end
   end
 
   # User repository

--- a/spec/warden/cognito/token_authenticable_strategie_spec.rb
+++ b/spec/warden/cognito/token_authenticable_strategie_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Warden::Cognito::TokenAuthenticatableStrategy do
   let(:headers) { { 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" } }
   let(:path) { '/v1/resource' }
   let(:env) { Rack::MockRequest.env_for(path, method: 'GET').merge(headers) }
-  let(:strategy) { described_class.new(env) }
+  subject(:strategy) { described_class.new(env) }
   let(:kb_uuid) { user.id }
   let(:decoded_token) do
     [

--- a/spec/warden/cognito/token_authenticable_strategie_spec.rb
+++ b/spec/warden/cognito/token_authenticable_strategie_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Warden::Cognito::TokenAuthenticatableStrategy do
   let(:headers) { { 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" } }
   let(:path) { '/v1/resource' }
   let(:env) { Rack::MockRequest.env_for(path, method: 'GET').merge(headers) }
-  subject(:strategy) { described_class.new(env) }
-  let(:kb_uuid) { user.id }
   let(:decoded_token) do
     [
       {
@@ -20,6 +18,8 @@ RSpec.describe Warden::Cognito::TokenAuthenticatableStrategy do
   end
 
   let(:client) { double 'Client' }
+
+  subject(:strategy) { described_class.new(env) }
 
   before do
     allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return client

--- a/spec/warden/integration/test_helpers_spec.rb
+++ b/spec/warden/integration/test_helpers_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'rack'
+
+RSpec.describe Warden::Cognito::TestHelpers do
+  include_context 'fixtures'
+  include_context 'configuration'
+
+  describe '#auth_headers' do
+    let(:headers) { { foo: 'bar' } }
+    let(:user_repository) { double 'UserRepository' }
+    let(:user) { double 'User' }
+    let(:cognito_id) { 'User Cognito Identifying Attribute Value' }
+
+    subject(:auth_headers) { Warden::Cognito::TestHelpers.auth_headers(headers, user) }
+
+    before do
+      Warden::Cognito.config.user_repository = user_repository
+      Warden::Cognito::TestHelpers.setup
+      allow(user).to receive(:cognito_id).and_return(cognito_id)
+    end
+
+    it 'overrides the headers with Bearer token in Authorization' do
+      expect(auth_headers).to match hash_including headers.except(:Authorization)
+      expect(auth_headers).to have_key :Authorization
+    end
+
+    it 'returns a valid token' do
+      token_decoder = token_decoder(auth_headers)
+
+      expect(token_decoder.validate!).to be_truthy
+    end
+
+    it 'returns a token identifying the provided user' do
+      token_decoder = token_decoder(auth_headers)
+
+      expect(user_repository).to receive(:find_by_cognito_attribute).with(cognito_id).and_return(user)
+      expect(Warden::Cognito::LocalUserMapper.new.call(token_decoder)).to eq user
+    end
+
+    def token_decoder(headers)
+      token = headers[:Authorization].split[1]
+      Warden::Cognito::TokenDecoder.new(token)
+    end
+  end
+end

--- a/spec/warden/integration/test_helpers_spec.rb
+++ b/spec/warden/integration/test_helpers_spec.rb
@@ -8,15 +8,14 @@ RSpec.describe Warden::Cognito::TestHelpers do
   describe '#auth_headers' do
     let(:headers) { { foo: 'bar' } }
     let(:user_repository) { double 'UserRepository' }
-    let(:user) { double 'User' }
     let(:cognito_id) { 'User Cognito Identifying Attribute Value' }
+    let(:user) { double 'User', cognito_id: cognito_id }
 
     subject(:auth_headers) { Warden::Cognito::TestHelpers.auth_headers(headers, user) }
 
     before do
       Warden::Cognito.config.user_repository = user_repository
       Warden::Cognito::TestHelpers.setup
-      allow(user).to receive(:cognito_id).and_return(cognito_id)
     end
 
     it 'overrides the headers with Bearer token in Authorization' do

--- a/spec/warden/integration/test_helpers_spec.rb
+++ b/spec/warden/integration/test_helpers_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Warden::Cognito::TestHelpers do
       token_decoder = token_decoder(auth_headers)
 
       expect(user_repository).to receive(:find_by_cognito_attribute).with(cognito_id).and_return(user)
-      expect(Warden::Cognito::LocalUserMapper.new.call(token_decoder)).to eq user
+      expect(Warden::Cognito::LocalUserMapper.find(token_decoder)).to eq user
     end
 
     def token_decoder(headers)

--- a/warden-cognito.gemspec
+++ b/warden-cognito.gemspec
@@ -5,7 +5,7 @@ require 'warden/cognito/version'
 Gem::Specification.new do |spec|
   spec.name          = 'warden-cognito'
   spec.version       = Warden::Cognito::VERSION
-  spec.authors       = ['Juan F. Pérez']
+  spec.authors       = ['Juan F. Pérez', 'Léo Figea']
   spec.email         = ['761794+jguitar@users.noreply.github.com']
 
   spec.summary       = 'Amazon Cognito authentication for Warden'


### PR DESCRIPTION
## Why?
To make the Gem more useful and the code using it (partially) testable!

## Changes
- Refactor to use [Dry::AutoInject](https://dry-rb.org/gems/dry-auto_inject/0.6/) as it was already there.
- Refactor to use the `jwk_loader` argument of [JWT](https://github.com/jwt/ruby-jwt#json-web-key-jwk)
- Refactor to. extract `LocalUserMapper` and `TokenDecoder` to make them available as part of this gem Api for any lib users!
- Add TestHelpers module