### PR TITLE
Fix - Remove rspec require in gem implementation

### DIFF
--- a/lib/warden/cognito/test_helpers.rb
+++ b/lib/warden/cognito/test_helpers.rb
@@ -1,5 +1,3 @@
-require 'rspec'
-
 module Warden
   module Cognito
     class TestHelpers


### PR DESCRIPTION
## Why?
🕵🏻‍♂️ Hotfix 🕵🏻‍♂️
Breaking the implementation as rspec is a dev dependency !

## Changes
- remove the faulty `require` left behind...