### PR TITLE
🚀 Bump warden-cognito to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0]
 - **Breaking Changes**: Configuration explicitly moved to `user_pools` object
 
 ## [0.2.3]
@@ -25,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Scratching the gem
 
-[Unreleased]: https://github.com/barkibu/warden-cognito/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/barkibu/warden-cognito/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/barkibu/warden-cognito/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/barkibu/warden-cognito/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/barkibu/warden-cognito/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/barkibu/warden-cognito/compare/v0.2.0...v0.2.1

--- a/lib/warden/cognito/version.rb
+++ b/lib/warden/cognito/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module Cognito
-    VERSION = '0.2.3'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end


### PR DESCRIPTION
## [0.3.0]
- **Breaking Changes**: Configuration explicitly moved to `user_pools` object