### PR TITLE
Allow selection of pool on Jwt generation in test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ AllCops:
     - 'db/**/*'
     - 'vendor/**/*'
 
+  TargetRubyVersion: 2.6
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Allow selection of `user_pool` when generating a jwt through the test helper
 
 ## [0.3.0]
 - **Breaking Changes**: Configuration explicitly moved to `user_pools` object

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ module Helpers
       end
     end
 
-    def auth_headers_for_user(user, headers = {})
-      Warden::Cognito::TestHelpers.auth_headers(headers, user)
+    def auth_headers_for_user(user, pool_identifier, headers = {})
+      Warden::Cognito::TestHelpers.auth_headers(headers, user, pool_identifier)
     end
 
-    def jwt_for_user(user)
-      auth_headers_for_user(user)[:Authorization].split[1]
+    def jwt_for_user(user, pool_identifier)
+      auth_headers_for_user(user, pool_identifier)[:Authorization].split[1]
     end
   end
 end

--- a/lib/warden/cognito/jwk_loader.rb
+++ b/lib/warden/cognito/jwk_loader.rb
@@ -5,7 +5,9 @@ module Warden
       include HasUserPoolIdentifier
 
       def jwt_issuer
-        jwk.issuer || "https://cognito-idp.#{user_pool.region}.amazonaws.com/#{user_pool.pool_id}"
+        return "#{user_pool.identifier}-#{jwk.issuer}" if jwk.issuer.present?
+
+        "https://cognito-idp.#{user_pool.region}.amazonaws.com/#{user_pool.pool_id}"
       end
 
       def issued?(token)

--- a/lib/warden/cognito/test_helpers.rb
+++ b/lib/warden/cognito/test_helpers.rb
@@ -12,8 +12,8 @@ module Warden
           Warden::Cognito.config.jwk = { key: jwk, issuer: local_issuer }
         end
 
-        def auth_headers(headers, user)
-          headers.merge(Authorization: "Bearer #{generate_token(user)}")
+        def auth_headers(headers, user, pool_identifier = Warden::Cognito.config.user_pools.first.identifier)
+          headers.merge(Authorization: "Bearer #{generate_token(user, pool_identifier)}")
         end
 
         def local_issuer
@@ -22,10 +22,10 @@ module Warden
 
         private
 
-        def generate_token(user)
+        def generate_token(user, pool_identifier)
           payload = { sub: user.object_id,
                       "#{identifying_attribute}": user.cognito_id,
-                      iss: local_issuer }
+                      iss: "#{pool_identifier}-#{local_issuer}" }
           headers = { kid: jwk.kid }
           JWT.encode(payload, jwk.keypair, 'RS256', headers)
         end

--- a/spec/warden/integration/test_helpers_spec.rb
+++ b/spec/warden/integration/test_helpers_spec.rb
@@ -10,8 +10,14 @@ RSpec.describe Warden::Cognito::TestHelpers do
     let(:user_repository) { double 'UserRepository' }
     let(:cognito_id) { 'User Cognito Identifying Attribute Value' }
     let(:user) { double 'User', cognito_id: cognito_id }
+    let(:user_pool_configurations) do
+      {
+        "#{pool_identifier}": { region: region, pool_id: pool_id, client_id: client_id },
+        particular_pool_identifier: { region: region, pool_id: pool_id, client_id: client_id }
+      }
+    end
 
-    subject(:auth_headers) { Warden::Cognito::TestHelpers.auth_headers(headers, user) }
+    subject(:auth_headers) { Warden::Cognito::TestHelpers.auth_headers(headers, user, :particular_pool_identifier) }
 
     before do
       Warden::Cognito.config.user_repository = user_repository
@@ -29,16 +35,17 @@ RSpec.describe Warden::Cognito::TestHelpers do
       expect(token_decoder.validate!).to be_truthy
     end
 
-    it 'returns a token identifying the provided user' do
+    it 'returns a token identifying the provided user with the specified pool identifier' do
       token_decoder = token_decoder(auth_headers)
 
-      expect(user_repository).to receive(:find_by_cognito_attribute).with(cognito_id, pool_identifier).and_return(user)
+      expect(user_repository).to receive(:find_by_cognito_attribute).with(cognito_id,
+                                                                          :particular_pool_identifier).and_return(user)
       expect(Warden::Cognito::LocalUserMapper.find(token_decoder)).to eq user
     end
 
     def token_decoder(headers)
       token = headers[:Authorization].split[1]
-      Warden::Cognito::TokenDecoder.new(token, Warden::Cognito.config.user_pools.first.identifier)
+      Warden::Cognito::TokenDecoder.new(token)
     end
   end
 end


### PR DESCRIPTION
## Why?

Having multiple configuration of user pool on one project, we need a way to select which pool supposedly generated the JWT when testing as depending on this value will be passed as `pool_identifier` to the different callbacks.

## Changes

- Accept `pool_identifier` on the `TestHelpers.auth_headers` (default to the first configured pool)
- Set the issuer on the jwt as a combination of the unique jwk and the specified `pool_identifier`
- Update `issued?` method to consider the `pool_identifier` to only return true when the appropriate pool configuration is loaded.

## Checklist

- [x] Test updated
- [x] ChangeLog entry added 
- [x] Readme  updated
