### PR TITLE
Fix / Use region from config on user pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.2]
+- Fix - specify region on scoped aws client
+
+## [0.3.1]
 - Allow selection of `user_pool` when generating a jwt through the test helper
 
 ## [0.3.0]
@@ -28,7 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Scratching the gem
 
-[Unreleased]: https://github.com/barkibu/warden-cognito/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/barkibu/warden-cognito/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/barkibu/warden-cognito/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/barkibu/warden-cognito/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/barkibu/warden-cognito/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/barkibu/warden-cognito/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/barkibu/warden-cognito/compare/v0.2.1...v0.2.2

--- a/lib/warden/cognito/cognito_client.rb
+++ b/lib/warden/cognito/cognito_client.rb
@@ -23,7 +23,7 @@ module Warden
       private
 
       def client
-        Aws::CognitoIdentityProvider::Client.new
+        Aws::CognitoIdentityProvider::Client.new region: user_pool.region
       end
 
       class << self

--- a/lib/warden/cognito/version.rb
+++ b/lib/warden/cognito/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module Cognito
-    VERSION = '0.3.1'.freeze
+    VERSION = '0.3.2'.freeze
   end
 end


### PR DESCRIPTION
## Why?

Whenever an access token needs to be identified, we pull the user from Cognito using the `get_user` method. The AwsClient looks for the env variable AWS_REGION as no region is specified on client instantiation.

## Changes

The pool is identified before pulling the user, we need to use the region for this specific pool instead of letting the AwsClient default to the potentially non existing AWS_REGION env var.