### PR TITLE
set the jti + exp claims on test tokens and allow passing in additional claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Improve test helpers to include `jti` and `exp` claims and accept user-supplied claims.
+
 ## [0.3.2]
 - Fix - specify region on scoped aws client
 

--- a/lib/warden/cognito/test_helpers.rb
+++ b/lib/warden/cognito/test_helpers.rb
@@ -12,8 +12,8 @@ module Warden
           Warden::Cognito.config.jwk = { key: jwk, issuer: local_issuer }
         end
 
-        def auth_headers(headers, user, pool_identifier = Warden::Cognito.config.user_pools.first.identifier)
-          headers.merge(Authorization: "Bearer #{generate_token(user, pool_identifier)}")
+        def auth_headers(headers, user, pool_identifier = Warden::Cognito.config.user_pools.first.identifier, claims = {})
+          headers.merge(Authorization: "Bearer #{generate_token(user, pool_identifier, claims)}")
         end
 
         def local_issuer
@@ -22,10 +22,14 @@ module Warden
 
         private
 
-        def generate_token(user, pool_identifier)
-          payload = { sub: user.object_id,
-                      "#{identifying_attribute}": user.cognito_id,
-                      iss: "#{pool_identifier}-#{local_issuer}" }
+        def generate_token(user, pool_identifier, claims={})
+          payload = {
+            sub: user.object_id,
+            "#{identifying_attribute}": user.cognito_id,
+            iss: "#{pool_identifier}-#{local_issuer}",
+            jti: SecureRandom.uuid,
+            exp: 1.hour.from_now.to_i,
+          }.merge(claims)
           headers = { kid: jwk.kid }
           JWT.encode(payload, jwk.keypair, 'RS256', headers)
         end

--- a/lib/warden/cognito/test_helpers.rb
+++ b/lib/warden/cognito/test_helpers.rb
@@ -12,7 +12,8 @@ module Warden
           Warden::Cognito.config.jwk = { key: jwk, issuer: local_issuer }
         end
 
-        def auth_headers(headers, user, pool_identifier = Warden::Cognito.config.user_pools.first.identifier, claims = {})
+        def auth_headers(headers, user, pool_identifier = Warden::Cognito.config.user_pools.first.identifier,
+                         claims = {})
           headers.merge(Authorization: "Bearer #{generate_token(user, pool_identifier, claims)}")
         end
 
@@ -22,13 +23,13 @@ module Warden
 
         private
 
-        def generate_token(user, pool_identifier, claims={})
+        def generate_token(user, pool_identifier, claims = {})
           payload = {
             sub: user.object_id,
             "#{identifying_attribute}": user.cognito_id,
             iss: "#{pool_identifier}-#{local_issuer}",
             jti: SecureRandom.uuid,
-            exp: 1.hour.from_now.to_i,
+            exp: 1.hour.from_now.to_i
           }.merge(claims)
           headers = { kid: jwk.kid }
           JWT.encode(payload, jwk.keypair, 'RS256', headers)


### PR DESCRIPTION
Subject says most - this extends the test helper to allow user-supplied claims and also adds the `jti` and `exp` claims.  My use case is implementing a denylist revocation strategy similarly to `warden-jwt` / `devise-jwt`, as well as validations around expired token behavior in my app.