### PR TITLE
Explicit default keyword for Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0]
+- Fix deprecated syntax on configuration
+
 ## [0.3.3]
 - Improve test helpers to include `jti` and `exp` claims and accept user-supplied claims.
 
@@ -36,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Scratching the gem
 
-[Unreleased]: https://github.com/barkibu/warden-cognito/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/barkibu/warden-cognito/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/barkibu/warden-cognito/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/barkibu/warden-cognito/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/barkibu/warden-cognito/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/barkibu/warden-cognito/compare/v0.3.0...v0.3.1

--- a/lib/warden/cognito.rb
+++ b/lib/warden/cognito.rb
@@ -36,13 +36,13 @@ module Warden
     module_function :jwk_config_keys, :jwk_instance, :user_pool_configuration_keys, :user_pool_configurations
 
     setting :user_repository
-    setting(:identifying_attribute, default: 'sub', &:to_s)
+    setting :identifying_attribute, default: 'sub', constructor: ->(attr) { attr.to_s }
     setting :after_local_user_not_found
     setting :cache, default: ActiveSupport::Cache::NullStore.new
 
-    setting(:jwk, default: nil) { |value| jwk_instance(value) }
+    setting :jwk, default: nil, constructor: ->(value) { jwk_instance(value) }
 
-    setting(:user_pools, []) { |value| user_pool_configurations(value) }
+    setting :user_pools, default: [], constructor: ->(value) { user_pool_configurations(value) }
 
     Import = Dry::AutoInject(config)
   end

--- a/lib/warden/cognito.rb
+++ b/lib/warden/cognito.rb
@@ -36,11 +36,11 @@ module Warden
     module_function :jwk_config_keys, :jwk_instance, :user_pool_configuration_keys, :user_pool_configurations
 
     setting :user_repository
-    setting(:identifying_attribute, 'sub', &:to_s)
+    setting(:identifying_attribute, default: 'sub', &:to_s)
     setting :after_local_user_not_found
-    setting :cache, ActiveSupport::Cache::NullStore.new
+    setting :cache, default: ActiveSupport::Cache::NullStore.new
 
-    setting(:jwk, nil) { |value| jwk_instance(value) }
+    setting(:jwk, default: nil) { |value| jwk_instance(value) }
 
     setting(:user_pools, []) { |value| user_pool_configurations(value) }
 

--- a/lib/warden/cognito/version.rb
+++ b/lib/warden/cognito/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module Cognito
-    VERSION = '0.3.3'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end


### PR DESCRIPTION
## Why?

Console keeps screaming: 
```log
[dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead
```