### PR TITLE
Silence a ROR 7.1 deprecation warning by using Rails.cache as the default cache, if its available

### DIFF
--- a/lib/warden/cognito.rb
+++ b/lib/warden/cognito.rb
@@ -38,7 +38,7 @@ module Warden
     setting :user_repository
     setting :identifying_attribute, default: 'sub', constructor: ->(attr) { attr.to_s }
     setting :after_local_user_not_found
-    setting :cache, default: ActiveSupport::Cache::NullStore.new
+    setting :cache, default: (defined?(Rails) ? Rails.cache : ActiveSupport::Cache::NullStore.new)
 
     setting :jwk, default: nil, constructor: ->(value) { jwk_instance(value) }
 


### PR DESCRIPTION
This PR started from an investigation into a deprecation warning on a ROR 7.0 -> 7.1 upgrade.  The specific error at the time was:

```
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
```

This is triggered by this line in lib/warden/cognito.rb:

```
setting :cache, default: ActiveSupport::Cache::NullStore.new
```

Of course, nowhere here is `cache_format_version` explicitly set (nor should it be), but rather this is the default value in ActiveSupport.  

* In the non-rails context, the warning is obvious - the default will change in an upcoming release.  
* In a rails context this is confusing because it gets displayed even in the presence of a `config.load_defaults 7.1` call in an app's config/application.rb file.  I believe this is because the `NullStore.new` call gets executed at `require` time and thus before the Rails app config hooks start firing.

Workarounds:

* We could call `ActiveSupport.cache_format_version = XX` in warden-cognito's land, if Rails isn't defined.  This seems bad because it might mess with an app's settings, and we don't really need to enforce a particular cache format here - that's not our job.
* We can change the default to be `Rails.cache` when Rails is defined.
* Other?

I opted for the 2nd option here since it seemed less intrusive and more in-line with what I'd expect in a Rails context.  It also removed the deprecation in my original app.