### PR TITLE
Allow ActiveSupport 8 — raise dependency ceiling to < 9.0

### DIFF
--- a/lib/warden/cognito/version.rb
+++ b/lib/warden/cognito/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module Cognito
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end

--- a/warden-cognito.gemspec
+++ b/warden-cognito.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency 'activesupport', ['>= 6.0', '< 8.0']
+  spec.add_dependency 'activesupport', ['>= 6.0', '< 9.0']
   spec.add_dependency 'aws-sdk-cognitoidentityprovider', '~> 1.47'
   spec.add_dependency 'dry-auto_inject', '~> 0.6'
   spec.add_dependency 'dry-configurable', '~> 0.9'


### PR DESCRIPTION
## Why?

The gemspec caps `activesupport < 8.0`, which blocks every consumer from upgrading to Rails 8 — connectedhealth-backend hit this on jump 4 of the framework-upgrade initiative (https://app.basecamp.com/3934852/buckets/36401275/todos/10060263116).

## Changes

- `activesupport` ceiling `< 8.0` → `< 9.0`. Floor unchanged at `>= 6.0`: existing consumers on 6.x/7.x are unaffected — same reasoning as barkibu/kb-ruby#100 (no runtime-dep changes beyond the ceiling; a scoped conservative update takes it without moving anything else).
- Version 1.1.0.

## Validation

Suite green against activesupport 8.1.3: **31 examples, 0 failures** (docker, ruby:3.2).

⚠️ This repo has no release automation: after merging, someone with rubygems ownership needs to `gem build && gem push` v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dppT6P16FuhSY8W32EgYu